### PR TITLE
feat: add `downloadResource` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ npx cap sync
 
 ### Android
 
+This API requires the following permission be added to your `AndroidManifest.xml` **before** the `application` tag:
+
+```xml
+<uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
+```
+
+You also need to add the following receiver **in** the `application` tag in your `AndroidManifest.xml`:
+
+```xml
+<receiver android:name="io.capawesome.capacitorjs.plugins.cloudinary.DownloadBroadcastReceiver" android:exported="true">
+  <intent-filter>
+    <action android:name="android.intent.action.DOWNLOAD_COMPLETE"/>
+  </intent-filter>
+</receiver>
+```
+
 #### Variables
 
 This plugin will use the following project variables (defined in your app’s `variables.gradle` file):
@@ -79,6 +95,13 @@ const uploadResource = async () => {
     resourceType: ResourceType.image,
     uploadPreset: 'my_preset',
   });
+};
+
+const downloadResource = async () => {
+  const { path } = await Cloudinary.downloadResource({
+    url: 'https://res.cloudinary.com/myCloudName/image/upload/v123/123.png',
+  });
+  return path;
 };
 ```
 
@@ -144,6 +167,12 @@ downloadResource(options: DownloadResourceOptions) => Promise<DownloadResourceRe
 ```
 
 Download a file from Cloudinary.
+
+On **Android**, the file will be downloaded to the `Downloads` directory.
+On **iOS**, the file will be downloaded to the temporary directory.
+
+It is recommended to copy the file to a permanent location for
+further processing after downloading.
 
 | Param         | Type                                                                        |
 | ------------- | --------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ const uploadResource = async () => {
 
 * [`initialize(...)`](#initialize)
 * [`uploadResource(...)`](#uploadresource)
+* [`downloadResource(...)`](#downloadresource)
 * [Interfaces](#interfaces)
 * [Enums](#enums)
 
@@ -136,6 +137,25 @@ Upload a file to Cloudinary.
 --------------------
 
 
+### downloadResource(...)
+
+```typescript
+downloadResource(options: DownloadResourceOptions) => Promise<DownloadResourceResult>
+```
+
+Download a file from Cloudinary.
+
+| Param         | Type                                                                        |
+| ------------- | --------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#downloadresourceoptions">DownloadResourceOptions</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#downloadresourceresult">DownloadResourceResult</a>&gt;</code>
+
+**Since:** 0.0.3
+
+--------------------
+
+
 ### Interfaces
 
 
@@ -169,6 +189,21 @@ Upload a file to Cloudinary.
 | **`uploadPreset`** | <code>string</code>                                   | The selected upload preset.                                        | 0.0.1 |
 | **`path`**         | <code>string</code>                                   | The path of the file to upload. Only available on Android and iOS. | 0.0.1 |
 | **`publicId`**     | <code>string</code>                                   | Assign a unique public identifier to the resource.                 | 0.0.1 |
+
+
+#### DownloadResourceResult
+
+| Prop       | Type                | Description                                                                                              | Since |
+| ---------- | ------------------- | -------------------------------------------------------------------------------------------------------- | ----- |
+| **`path`** | <code>string</code> | The path of the downloaded resource where it is stored on the device. Only available on Android and iOS. | 0.0.3 |
+| **`blob`** | <code>Blob</code>   | The downloaded resource as a blob. Only available on Web.                                                | 0.0.1 |
+
+
+#### DownloadResourceOptions
+
+| Prop      | Type                | Description                          | Since |
+| --------- | ------------------- | ------------------------------------ | ----- |
+| **`url`** | <code>string</code> | The url of the resource to download. | 0.0.3 |
 
 
 ### Enums

--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/cloudinary/Cloudinary.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/cloudinary/Cloudinary.java
@@ -1,15 +1,34 @@
 package io.capawesome.capacitorjs.plugins.cloudinary;
 
+import static android.content.Context.DOWNLOAD_SERVICE;
+
+import android.app.DownloadManager;
 import android.net.Uri;
+import android.os.Environment;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.cloudinary.android.MediaManager;
 import com.cloudinary.android.UploadRequest;
 import com.cloudinary.android.callback.ErrorInfo;
 import com.cloudinary.android.callback.UploadCallback;
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
 public class Cloudinary {
+
+    class ActiveDownload {
+
+        public String path;
+        public DownloadResourceResultCallback callback;
+
+        ActiveDownload(String path, DownloadResourceResultCallback callback) {
+            this.path = path;
+            this.callback = callback;
+        }
+    }
+
+    private HashMap<Long, ActiveDownload> activeDownloads = new HashMap<Long, ActiveDownload>();
 
     private CloudinaryPlugin plugin;
 
@@ -59,5 +78,26 @@ public class Cloudinary {
                 }
             )
             .dispatch();
+    }
+
+    public void downloadResource(String url, DownloadResourceResultCallback callback) {
+        String fileName = url.substring(url.lastIndexOf("/") + 1);
+        DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url))
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_HIDDEN)
+            .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
+            .setAllowedOverMetered(true)
+            .setAllowedOverRoaming(true);
+        DownloadManager downloadManager = (DownloadManager) plugin.getContext().getSystemService(DOWNLOAD_SERVICE);
+        long downloadId = downloadManager.enqueue(request);
+        String path = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), fileName).getAbsolutePath();
+        activeDownloads.put(downloadId, new ActiveDownload(path, callback));
+    }
+
+    public void handleDownloadCompleted(long downloadId) {
+        ActiveDownload download = activeDownloads.get(downloadId);
+        if (download == null) {
+            return;
+        }
+        download.callback.success(download.path);
     }
 }

--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/cloudinary/DownloadBroadcastReceiver.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/cloudinary/DownloadBroadcastReceiver.java
@@ -1,0 +1,18 @@
+package io.capawesome.capacitorjs.plugins.cloudinary;
+
+import android.app.DownloadManager;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class DownloadBroadcastReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        if (DownloadManager.ACTION_DOWNLOAD_COMPLETE.equals(action)) {
+            long downloadId = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1);
+            CloudinaryPlugin.onDownloadCompleted(downloadId);
+        }
+    }
+}

--- a/android/src/main/java/io/capawesome/capacitorjs/plugins/cloudinary/DownloadResourceResultCallback.java
+++ b/android/src/main/java/io/capawesome/capacitorjs/plugins/cloudinary/DownloadResourceResultCallback.java
@@ -1,0 +1,6 @@
+package io.capawesome.capacitorjs.plugins.cloudinary;
+
+public interface DownloadResourceResultCallback {
+    void success(String path);
+    void error(String message);
+}

--- a/ios/Plugin/CloudinaryPlugin.m
+++ b/ios/Plugin/CloudinaryPlugin.m
@@ -6,4 +6,5 @@
 CAP_PLUGIN(CloudinaryPlugin, "Cloudinary",
            CAP_PLUGIN_METHOD(initialize, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(uploadResource, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(downloadResource, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/CloudinaryPlugin.swift
+++ b/ios/Plugin/CloudinaryPlugin.swift
@@ -14,6 +14,7 @@ public class CloudinaryPlugin: CAPPlugin {
     public let errorPathMissing = "path must be provided."
     public let errorResourceTypeMissing = "resourceType must be provided."
     public let errorUploadPresetMissing = "uploadPreset must be provided."
+    public let errorUrlMissing = "url must be provided."
 
     private var implementation: Cloudinary?
     private var initialized = false
@@ -61,6 +62,30 @@ public class CloudinaryPlugin: CAPPlugin {
             }
             let result = CloudinaryHelper.createUploadResourceResult(resultData)
             call.resolve(result)
+        })
+    }
+
+    @objc func downloadResource(_ call: CAPPluginCall) {
+        if !initialized {
+            call.reject(errorNotInitialized)
+            return
+        }
+        guard let url = call.getString("url") else {
+            call.reject(errorUrlMissing)
+            return
+        }
+        implementation?.downloadResource(url: url, completion: { path, errorMessage in
+            if let errorMessage = errorMessage {
+                call.reject(errorMessage)
+                return
+            }
+            guard let path = path else {
+                call.reject(self.errorUnknown)
+                return
+            }
+            call.resolve([
+                "path": path
+            ])
         })
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -18,6 +18,12 @@ export interface CloudinaryPlugin {
   /**
    * Download a file from Cloudinary.
    *
+   * On **Android**, the file will be downloaded to the `Downloads` directory.
+   * On **iOS**, the file will be downloaded to the temporary directory.
+   *
+   * It is recommended to copy the file to a permanent location for
+   * further processing after downloading.
+   *
    * @since 0.0.3
    */
   downloadResource(

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -15,6 +15,14 @@ export interface CloudinaryPlugin {
    * @since 0.0.1
    */
   uploadResource(options: UploadResourceOptions): Promise<UploadResourceResult>;
+  /**
+   * Download a file from Cloudinary.
+   *
+   * @since 0.0.3
+   */
+  downloadResource(
+    options: DownloadResourceOptions,
+  ): Promise<DownloadResourceResult>;
 }
 
 /**
@@ -132,6 +140,40 @@ export interface UploadResourceResult {
    * @since 0.0.1
    */
   url: string;
+}
+
+/**
+ * @since 0.0.3
+ */
+export interface DownloadResourceOptions {
+  /**
+   * The url of the resource to download.
+   *
+   * @since 0.0.3
+   */
+  url: string;
+}
+
+/**
+ * @since 0.0.3
+ */
+export interface DownloadResourceResult {
+  /**
+   * The path of the downloaded resource where it is stored on the device.
+   *
+   * Only available on Android and iOS.
+   *
+   * @since 0.0.3
+   */
+  path?: string;
+  /**
+   * The downloaded resource as a blob.
+   *
+   * Only available on Web.
+   *
+   * @since 0.0.1
+   */
+  blob?: Blob;
 }
 
 /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,6 +2,8 @@ import { WebPlugin } from '@capacitor/core';
 
 import type {
   CloudinaryPlugin,
+  DownloadResourceOptions,
+  DownloadResourceResult,
   InitializeOptions,
   UploadResourceOptions,
   UploadResourceResult,
@@ -60,7 +62,16 @@ export class CloudinaryWeb extends WebPlugin implements CloudinaryPlugin {
     };
   }
 
-  public async uploadResourceChunk(
+  public async downloadResource(
+    options: DownloadResourceOptions,
+  ): Promise<DownloadResourceResult> {
+    const blob = await fetch(options.url).then(res => res.blob());
+    return {
+      blob,
+    };
+  }
+
+  private async uploadResourceChunk(
     options: UploadResourceOptions,
     uniqueUploadId: string,
     start: number,


### PR DESCRIPTION
BREAKING CHANGE: On Android, you now need changes in the `AndroidManifest.xml` file (see `README.md`).

Had to use the Android `DownloadManager` because I could not implement the download with the Cloudinary Android SDK (see https://github.com/cloudinary/cloudinary_android/issues/152).
Therefore, the files must be downloaded to an external directory (see https://stackoverflow.com/a/54984938/6731412).